### PR TITLE
Fixing Loot Allocation

### DIFF
--- a/pkg/infra/game/agent/base_agent.go
+++ b/pkg/infra/game/agent/base_agent.go
@@ -138,3 +138,7 @@ func (a *Agent) CompileTrustMessage(agentMap map[commons.ID]Agent) message.Trust
 	// send off
 	return *trustMsg
 }
+
+func (ba *BaseAgent) RequestLootProposal() {
+
+}

--- a/pkg/infra/game/stage/discussion/resolution.go
+++ b/pkg/infra/game/stage/discussion/resolution.go
@@ -251,17 +251,23 @@ func addWantedLootToItemAllocMap(wantedLoot immutable.SortedMap[commons.ItemID, 
 func buildAllocation(pool *commons.ImmutableList[state.Item], proposedLooters []commons.ID, allocation map[commons.ID]map[commons.ItemID]struct{}) {
 	idx := 0
 	iterator := pool.Iterator()
+	// iterate over all items in pool
 	for !iterator.Done() {
 		if idx >= len(proposedLooters) {
 			break
 		}
+		// get next item in pool
 		next, _ := iterator.Next()
-		if m, ok := allocation[proposedLooters[idx]]; ok {
-			m[next.Id()] = struct{}{}
-		} else {
-			m := make(map[commons.ItemID]struct{})
-			m[next.Id()] = struct{}{}
-			allocation[proposedLooters[idx]] = m
+		for idx := 0; idx < len(proposedLooters); idx++ {
+			// if agent is in allocation already, add item to their key
+			if m, ok := allocation[proposedLooters[idx]]; ok {
+				m[next.Id()] = struct{}{}
+			} else {
+				// else, add agent to allocation and assign item to their key
+				m := make(map[commons.ItemID]struct{})
+				m[next.Id()] = struct{}{}
+				allocation[proposedLooters[idx]] = m
+			}
 		}
 	}
 }

--- a/pkg/infra/game/stage/discussion/resolution.go
+++ b/pkg/infra/game/stage/discussion/resolution.go
@@ -249,16 +249,15 @@ func addWantedLootToItemAllocMap(wantedLoot immutable.SortedMap[commons.ItemID, 
 }
 
 func buildAllocation(pool *commons.ImmutableList[state.Item], proposedLooters []commons.ID, allocation map[commons.ID]map[commons.ItemID]struct{}) {
-	idx := 0
 	iterator := pool.Iterator()
 	// iterate over all items in pool
 	for !iterator.Done() {
-		if idx >= len(proposedLooters) {
+		if len(proposedLooters) == 0 {
 			break
 		}
 		// get next item in pool
 		next, _ := iterator.Next()
-		for idx := 0; idx < len(proposedLooters); idx++ {
+		for idx, _ := range proposedLooters {
 			// if agent is in allocation already, add item to their key
 			if m, ok := allocation[proposedLooters[idx]]; ok {
 				m[next.Id()] = struct{}{}

--- a/pkg/infra/game/stage/discussion/resolution.go
+++ b/pkg/infra/game/stage/discussion/resolution.go
@@ -122,10 +122,10 @@ func getAllocation(gs state.State, agentMap map[commons.ID]agent.Agent, pool *st
 	}
 	getsWeapon, getsShield, getsHealthPotion, getsStaminaPotion := demandList(gs, agentMap, predicate)
 	m := make(map[commons.ID]map[commons.ItemID]struct{})
-	buildAllocation(pool.Weapons(), getsWeapon, m)
-	buildAllocation(pool.Shields(), getsShield, m)
-	buildAllocation(pool.HpPotions(), getsHealthPotion, m)
-	buildAllocation(pool.StaminaPotions(), getsStaminaPotion, m)
+	buildEligibility(pool.Weapons(), getsWeapon, m)
+	buildEligibility(pool.Shields(), getsShield, m)
+	buildEligibility(pool.HpPotions(), getsHealthPotion, m)
+	buildEligibility(pool.StaminaPotions(), getsStaminaPotion, m)
 
 	wantedItems := make(map[commons.ItemID]map[commons.ID]struct{})
 
@@ -248,24 +248,24 @@ func addWantedLootToItemAllocMap(wantedLoot immutable.SortedMap[commons.ItemID, 
 	}
 }
 
-func buildAllocation(pool *commons.ImmutableList[state.Item], proposedLooters []commons.ID, allocation map[commons.ID]map[commons.ItemID]struct{}) {
+func buildEligibility(pool *commons.ImmutableList[state.Item], proposedLooters []commons.ID, allocation map[commons.ID]map[commons.ItemID]struct{}) {
+	if len(proposedLooters) == 0 {
+		return
+	}
 	iterator := pool.Iterator()
 	// iterate over all items in pool
 	for !iterator.Done() {
-		if len(proposedLooters) == 0 {
-			break
-		}
 		// get next item in pool
 		next, _ := iterator.Next()
-		for idx, _ := range proposedLooters {
+		for _, looter := range proposedLooters {
 			// if agent is in allocation already, add item to their key
-			if m, ok := allocation[proposedLooters[idx]]; ok {
+			if m, ok := allocation[looter]; ok {
 				m[next.Id()] = struct{}{}
 			} else {
 				// else, add agent to allocation and assign item to their key
 				m := make(map[commons.ItemID]struct{})
 				m[next.Id()] = struct{}{}
-				allocation[proposedLooters[idx]] = m
+				allocation[looter] = m
 			}
 		}
 	}

--- a/pkg/infra/teams/team3/helpers.go
+++ b/pkg/infra/teams/team3/helpers.go
@@ -1,11 +1,13 @@
 package team3
 
 import (
+	"infra/config"
 	"infra/game/agent"
 	"infra/game/commons"
 	"math"
 	"math/rand"
-	"os"
+
+	// "os"
 	"strconv"
 )
 
@@ -99,11 +101,13 @@ func AverageArray(in []float64) float64 {
 }
 
 func GetStartingHP() int {
-	n, _ := strconv.ParseUint(os.Getenv("STARTING_HP"), 10, 0)
+	// n, _ := strconv.ParseUint(os.Getenv("STARTING_HP"), 10, 0)
+	n := config.EnvToUint("STARTING_HP", 1000)
 	return int(n)
 }
 func GetStartingStamina() int {
-	n, _ := strconv.ParseUint(os.Getenv("BASE_STAMINA"), 10, 0)
+	// n, _ := strconv.ParseUint(os.Getenv("BASE_STAMINA"), 10, 0)
+	n := config.EnvToUint("BASE_STAMINA", 2000)
 	return int(n)
 }
 


### PR DESCRIPTION
fixed loot allocation and parameterised some internal variables

- due to contracts, only weapons are allocated in the first levels (all agents are eligible for all weapons)