### PR TITLE
Remove redundant (performance hindering) mutexes

### DIFF
--- a/pkg/infra/game/stage/update/update.go
+++ b/pkg/infra/game/stage/update/update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/benbjohnson/immutable"
 )
 
-func UpdateInternalStates(agentMap map[commons.ID]agent.Agent, globalState *state.State, immutableFightRounds *commons.ImmutableList[decision.ImmutableFightResult], votesResult *immutable.Map[decision.Intent, uint]) map[commons.ID]logging.AgentLog {
+func InternalStates(agentMap map[commons.ID]agent.Agent, globalState *state.State, immutableFightRounds *commons.ImmutableList[decision.ImmutableFightResult], votesResult *immutable.Map[decision.Intent, uint]) map[commons.ID]logging.AgentLog {
 	var wg sync.WaitGroup
 	agentLogChan := make(chan logging.AgentLog)
 	for id, a := range agentMap {

--- a/pkg/infra/game/stages/stages.go
+++ b/pkg/infra/game/stages/stages.go
@@ -75,9 +75,9 @@ func AgentFightDecisions(state state.State, agents map[commons.ID]agent.Agent, p
 func UpdateInternalStates(agentMap map[commons.ID]agent.Agent, globalState *state.State, immutableFightRounds *commons.ImmutableList[decision.ImmutableFightResult], votesResult *immutable.Map[decision.Intent, uint]) map[commons.ID]logging.AgentLog {
 	switch Mode {
 	// case "1":
-	// 	return t1.UpdateInternalStates(agentMap, globalState, immutableFightRounds, votesResult)
+	// 	return t1.InternalStates(agentMap, globalState, immutableFightRounds, votesResult)
 	default:
-		return update.UpdateInternalStates(agentMap, globalState, immutableFightRounds, votesResult)
+		return update.InternalStates(agentMap, globalState, immutableFightRounds, votesResult)
 	}
 }
 

--- a/pkg/infra/teams/team3/loot_strat.go
+++ b/pkg/infra/teams/team3/loot_strat.go
@@ -92,13 +92,10 @@ func (a *AgentThree) HandleLootInformation(m message.TaggedInformMessage[message
 
 // forcibly call at start of loot phase to begin proceedings
 func (a *AgentThree) RequestLootProposal(baseAgent agent.BaseAgent) { // put your logic here now, instead
-	a.mutex.Lock()
 	sendProposal := rand.Intn(100)
 	if sendProposal > a.personality {
-		a.mutex.Unlock()
 		return
 	}
-	a.mutex.Unlock()
 	// general and send a loot proposal at the start of every turn
 	baseAgent.SendLootProposalToLeader(a.generateLootProposal(baseAgent))
 }

--- a/pkg/infra/teams/team3/messaging.go
+++ b/pkg/infra/teams/team3/messaging.go
@@ -4,7 +4,6 @@ import (
 	"infra/game/agent"
 	"infra/game/commons"
 	"infra/game/message"
-	"sync"
 )
 
 func agentInList(agentID commons.ID, messageList []commons.ID) bool {
@@ -72,9 +71,6 @@ func (a *AgentThree) HandleTrustMessage(m message.TaggedMessage) {
 	mes := m.Message()
 	t := mes.(message.Trust)
 
-	mutex := sync.Mutex{}
-	mutex.Lock()
-
 	// Gossip IS reputation map ---> one thread will read it, one thread will write it.
 	// Shallow copy introduced in Compile
 
@@ -91,7 +87,6 @@ func (a *AgentThree) HandleTrustMessage(m message.TaggedMessage) {
 
 	}
 	a.socialCap[m.Sender()] += 1
-	mutex.Unlock()
 	//fmt.Println("sender is", t.Recipients, m.Sender(), a.socialCap[m.Sender()])
 	// This function is type void - you can do whatever you want with it. I would suggest keeping a local dictionary
 


### PR DESCRIPTION
Removes many needless mutexes added erroneously

The mutexes are unnecessary in various cases, one of which in fact forces execution to be sequential
