### PR TITLE
(perf) Profiler indicated improvements

### DIFF
--- a/pkg/infra/game/agent/base_agent.go
+++ b/pkg/infra/game/agent/base_agent.go
@@ -119,26 +119,6 @@ func (ba *BaseAgent) HandleTrustMessage(m message.Trust) {
 	// fmt.Println("RECEIVED: ", reflect.TypeOf(m))
 }
 
-//func (a *Agent) CompileTrustMessage(agentMap map[commons.ID]Agent) message.Trust {
-//
-//	keys := make([]commons.ID, len(agentMap))
-//
-//	i := 0
-//	for k := range agentMap {
-//		keys[i] = k
-//		i++
-//	}
-//
-//	// declare new trust message
-//	trustMsg := new(message.Trust)
-//
-//	// put stuff inside
-//	trustMsg.MakeNewTrust(keys, make(map[string]float64))
-//
-//	// send off
-//	return *trustMsg
-//}
-
 func (ba *BaseAgent) RequestLootProposal() {
 
 }

--- a/pkg/infra/game/agent/base_agent.go
+++ b/pkg/infra/game/agent/base_agent.go
@@ -119,25 +119,25 @@ func (ba *BaseAgent) HandleTrustMessage(m message.Trust) {
 	// fmt.Println("RECEIVED: ", reflect.TypeOf(m))
 }
 
-func (a *Agent) CompileTrustMessage(agentMap map[commons.ID]Agent) message.Trust {
-
-	keys := make([]commons.ID, len(agentMap))
-
-	i := 0
-	for k := range agentMap {
-		keys[i] = k
-		i++
-	}
-
-	// declare new trust message
-	trustMsg := new(message.Trust)
-
-	// put stuff inside
-	trustMsg.MakeNewTrust(keys, make(map[string]float64))
-
-	// send off
-	return *trustMsg
-}
+//func (a *Agent) CompileTrustMessage(agentMap map[commons.ID]Agent) message.Trust {
+//
+//	keys := make([]commons.ID, len(agentMap))
+//
+//	i := 0
+//	for k := range agentMap {
+//		keys[i] = k
+//		i++
+//	}
+//
+//	// declare new trust message
+//	trustMsg := new(message.Trust)
+//
+//	// put stuff inside
+//	trustMsg.MakeNewTrust(keys, make(map[string]float64))
+//
+//	// send off
+//	return *trustMsg
+//}
 
 func (ba *BaseAgent) RequestLootProposal() {
 

--- a/pkg/infra/game/agent/trust.go
+++ b/pkg/infra/game/agent/trust.go
@@ -1,11 +1,12 @@
 package agent
 
 import (
+	"github.com/benbjohnson/immutable"
 	"infra/game/commons"
 	"infra/game/message"
 )
 
 type Trust interface {
-	CompileTrustMessage(agentMap map[commons.ID]Agent) message.Trust
+	CompileTrustMessage(agentMap *immutable.Map[commons.ID, Agent]) message.Trust
 	HandleTrustMessage(message message.TaggedMessage)
 }

--- a/pkg/infra/game/agent/trust.go
+++ b/pkg/infra/game/agent/trust.go
@@ -7,6 +7,6 @@ import (
 )
 
 type Trust interface {
-	CompileTrustMessage(agentMap *immutable.Map[commons.ID, Agent]) message.Trust
+	CompileTrustMessage(agentMap *immutable.Map[commons.ID, Agent]) (*message.Trust, []commons.ID)
 	HandleTrustMessage(message message.TaggedMessage)
 }

--- a/pkg/infra/game/example/random.go
+++ b/pkg/infra/game/example/random.go
@@ -304,7 +304,7 @@ func (r *RandomAgent) PruneAgentList(agentMap map[commons.ID]agent.Agent) map[co
 	return agentMap
 }
 
-func (r *RandomAgent) CompileTrustMessage(agentMap map[commons.ID]agent.Agent) message.Trust
+func (r *RandomAgent) CompileTrustMessage(agentMap *immutable.Map[commons.ID, agent.Agent]) message.Trust
 
 func (r *RandomAgent) HandleTrustMessage(message message.TaggedMessage)
 

--- a/pkg/infra/game/message/message.go
+++ b/pkg/infra/game/message/message.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"github.com/benbjohnson/immutable"
 	"infra/game/commons"
 	"infra/game/state"
 )
@@ -44,13 +45,15 @@ type StartLoot struct {
 }
 
 type Trust struct {
-	Recipients []commons.ID
-	Gossip     map[commons.ID]float64
+	gossip immutable.Map[commons.ID, float64]
 }
 
-func (t *Trust) MakeNewTrust(recips []commons.ID, gos map[commons.ID]float64) {
-	t.Recipients = recips
-	t.Gossip = gos
+func (t Trust) Gossip() *immutable.Map[commons.ID, float64] {
+	return &t.gossip
+}
+
+func NewTrust(gossip map[commons.ID]float64) *Trust {
+	return &Trust{gossip: commons.MapToImmutable(gossip)}
 }
 
 func (t Trust) sealedMessage() {

--- a/pkg/infra/game/stage/discussion/resolution.go
+++ b/pkg/infra/game/stage/discussion/resolution.go
@@ -128,7 +128,6 @@ func getAllocation(gs state.State, agentMap map[commons.ID]agent.Agent, pool *st
 	buildEligibility(pool.StaminaPotions(), getsStaminaPotion, agentToElibilityList)
 
 	return agentToElibilityList
-
 }
 
 // 	wantedItems := make(map[commons.ItemID]map[commons.ID]struct{})

--- a/pkg/infra/game/stage/fight/fight.go
+++ b/pkg/infra/game/stage/fight/fight.go
@@ -81,6 +81,7 @@ func AgentFightDecisions(state state.State, agents map[commons.ID]agent.Agent, p
 	time.Sleep(25 * time.Millisecond)
 	for id, c := range channelsMap {
 		closures[id] <- struct{}{}
+		close(closures[id])
 		go func(recv <-chan message.TaggedMessage) {
 			for m := range recv {
 				switch m.Message().(type) {

--- a/pkg/infra/game/stage/loot/loot.go
+++ b/pkg/infra/game/stage/loot/loot.go
@@ -136,7 +136,7 @@ func AgentLootDecisions(
 
 // 		// if items is of length 1, then take allocation
 // 		if len(items) == 1 {
-// 			// assign the only piece of loot they are eligable for
+// 			// assign the only piece of loot they are eligible for
 // 			for item := range items {
 // 				assignChosenItem(item, weaponSet, shieldSet, hpPotionSet, staminaPotionSet, &agentState)
 // 			}
@@ -144,7 +144,7 @@ func AgentLootDecisions(
 // 			// choose the most needed item from the list of allocated items
 // 			item := a.ChooseItem(*a.BaseAgent, items, weaponSet, shieldSet, hpPotionSet, staminaPotionSet)
 
-// 			// asign the most needed item to the agent
+// 			// assign the most needed item to the agent
 // 			assignChosenItem(item.Id(), weaponSet, shieldSet, hpPotionSet, staminaPotionSet, &agentState)
 // 		}
 
@@ -155,7 +155,6 @@ func AgentLootDecisions(
 // }
 
 func HandleLootAllocationExhaustive(globalState state.State, pool *state.LootPool, looters []agent.Agent) *state.State {
-
 	if len(looters) == 0 {
 		return &globalState
 	}
@@ -237,7 +236,6 @@ func HandleLootAllocationExhaustive(globalState state.State, pool *state.LootPoo
 }
 
 func checkDistinctPreferences(prefs []state.ItemName) bool {
-
 	if len(prefs) != 4 {
 		return false
 	}
@@ -380,7 +378,7 @@ func assignChosenItem(item string, weaponSet map[string]uint, shieldSet map[stri
 
 // }
 
-// // works bc normalization changes the data distribution, so small sheild/weapon difference values are significant enough now
+// // works bc normalization changes the data distribution, so small shield/weapon difference values are significant enough now
 // func normalize4El(x, y, z, w float64) (float64, float64, float64, float64) {
 // 	maxVal := minMax4(true, [...]float64{x, y, z, w})
 // 	minVal := minMax4(false, [...]float64{x, y, z, w})
@@ -399,7 +397,7 @@ func assignChosenItem(item string, weaponSet map[string]uint, shieldSet map[stri
 // 	return ans
 // }
 
-// didn't work as mean scaling just recenters the distribution -> sheild/weapon values were too small compared to the rest
+// didn't work as mean scaling just recenters the distribution -> shield/weapon values were too small compared to the rest
 // func meanScale4El(el1 float64, el2 float64, el3 float64, el4 float64) (float64, float64, float64, float64) {
 // 	var mean float64 = (el1 + el2 + el3 + el4) / 4.0
 // 	// fmt.Println(el1, el2, el3, el4)

--- a/pkg/infra/game/stages/stages.go
+++ b/pkg/infra/game/stages/stages.go
@@ -89,8 +89,7 @@ func HandleTrustStage(agentMap map[commons.ID]agent.Agent, channelsMap map[commo
 	immutableAgentMap := commons.MapToImmutable(agentMap)
 	var wg sync.WaitGroup
 	for _, a := range agentMap {
-		msg := a.Strategy.CompileTrustMessage(&immutableAgentMap)
-		senderList := msg.Recipients
+		msg, senderList := a.Strategy.CompileTrustMessage(&immutableAgentMap)
 		a := a
 
 		for _, ag := range senderList {

--- a/pkg/infra/game/stages/stages.go
+++ b/pkg/infra/game/stages/stages.go
@@ -140,7 +140,6 @@ func AgentPruneMapping(agentMap map[commons.ID]agent.Agent, globalState *state.S
 	}
 	// leader has died, hence no sanctioning
 	return agentMap
-
 }
 
 func AgentMapToSortedArray(prunedMap map[commons.ID]agent.Agent, globalState *state.State) []agent.Agent {

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -219,7 +219,6 @@ func startGameLoop() {
 
 			// log last round if we lose
 			if float64(len(agentMap)) < math.Ceil(float64(gameConfig.ThresholdPercentage)*float64(gameConfig.InitialNumAgents)) {
-
 				logLevel(levelLog, agentMap, w)
 
 				logging.Log(logging.Info, nil, fmt.Sprintf("Lost on level %d  with %d remaining", globalState.CurrentLevel, len(agentMap)))

--- a/pkg/infra/main_helper.go
+++ b/pkg/infra/main_helper.go
@@ -263,7 +263,6 @@ func initCsvLogging() (*csv.Writer, *os.File) {
 	return w, csvFile
 }
 func logLevel(levelLog logging.LevelStages, agentmap map[string]agent.Agent, w *csv.Writer) {
-
 	// quantize personalities to count them
 	countSelfless := 0
 	countSelfish := 0
@@ -281,7 +280,6 @@ func logLevel(levelLog logging.LevelStages, agentmap map[string]agent.Agent, w *
 		} else {
 			countCollective += 1
 		}
-
 	}
 	countAgentint := len(agentMap)
 	if countAgentint > 0 {

--- a/pkg/infra/sanctionUtils/sanctions.go
+++ b/pkg/infra/sanctionUtils/sanctions.go
@@ -30,7 +30,6 @@ func (s *SanctionActivity) UpdateSanction() {
 	if s.duration == 0 {
 		s.sanctionActive = false
 	}
-
 }
 
 var GlobalSanctionMap map[commons.ID]SanctionActivity = make(map[commons.ID]SanctionActivity)

--- a/pkg/infra/teams/team3/agent3.go
+++ b/pkg/infra/teams/team3/agent3.go
@@ -1,6 +1,7 @@
 package team3
 
 import (
+	"github.com/benbjohnson/immutable"
 	cmdline "infra/cmdLine"
 	"infra/config"
 	"infra/game/agent"
@@ -9,9 +10,6 @@ import (
 	"infra/logging"
 	sanctions "infra/sanctionUtils"
 	"math"
-	"sync"
-
-	"github.com/benbjohnson/immutable"
 )
 
 type AgentThree struct {
@@ -48,8 +46,6 @@ type AgentThree struct {
 	activeSanctionMap map[commons.ID]sanctions.SanctionActivity
 	// Keep track of previous sanction applied as a leader
 	sanctionLength int
-
-	mutex sync.RWMutex
 }
 
 // Update internal parameters at the end of each stage
@@ -147,13 +143,11 @@ func (a *AgentThree) UpdatePersonality(baseAgent agent.BaseAgent) {
 		increment = 0.0
 	}
 	increment = clampFloat(increment, -5.0, 5.0)
-	a.mutex.Lock()
 	// update personality
 	a.personality = a.personality + int(math.Ceil(increment))
 	// keep within maxMin personality
 	a.personality = clampInt(a.personality, 0, 100)
 	// reset initial change to new value.
-	a.mutex.Unlock()
 	a.changeInit = changeNow
 }
 
@@ -181,7 +175,6 @@ func NewAgentThreeNeutral() agent.Strategy {
 		samplePercent:     0.25,
 		sanctionHistory:   make(map[commons.ID]([]int)),
 		activeSanctionMap: make(map[commons.ID]sanctions.SanctionActivity),
-		mutex:             sync.RWMutex{},
 		sanctionLength:    0,
 	}
 }
@@ -210,7 +203,6 @@ func NewAgentThreePassive() agent.Strategy {
 		samplePercent:     0.25,
 		sanctionHistory:   make(map[commons.ID]([]int)),
 		activeSanctionMap: make(map[commons.ID]sanctions.SanctionActivity),
-		mutex:             sync.RWMutex{},
 		sanctionLength:    0,
 	}
 }
@@ -238,7 +230,6 @@ func NewAgentThreeAggressive() agent.Strategy {
 		samplePercent:     0.25,
 		sanctionHistory:   make(map[commons.ID]([]int)),
 		activeSanctionMap: make(map[commons.ID]sanctions.SanctionActivity),
-		mutex:             sync.RWMutex{},
 		sanctionLength:    0,
 	}
 }

--- a/pkg/infra/teams/team3/agent3.go
+++ b/pkg/infra/teams/team3/agent3.go
@@ -10,6 +10,7 @@ import (
 	"infra/logging"
 	sanctions "infra/sanctionUtils"
 	"math"
+	"math/rand"
 )
 
 type AgentThree struct {
@@ -46,6 +47,7 @@ type AgentThree struct {
 	activeSanctionMap map[commons.ID]sanctions.SanctionActivity
 	// Keep track of previous sanction applied as a leader
 	sanctionLength int
+	rng            *rand.Rand
 }
 
 // Update internal parameters at the end of each stage
@@ -176,6 +178,7 @@ func NewAgentThreeNeutral() agent.Strategy {
 		sanctionHistory:   make(map[commons.ID]([]int)),
 		activeSanctionMap: make(map[commons.ID]sanctions.SanctionActivity),
 		sanctionLength:    0,
+		rng:               rand.New(rand.NewSource(rand.Int63())),
 	}
 }
 
@@ -204,6 +207,7 @@ func NewAgentThreePassive() agent.Strategy {
 		sanctionHistory:   make(map[commons.ID]([]int)),
 		activeSanctionMap: make(map[commons.ID]sanctions.SanctionActivity),
 		sanctionLength:    0,
+		rng:               rand.New(rand.NewSource(rand.Int63())),
 	}
 }
 func NewAgentThreeAggressive() agent.Strategy {
@@ -231,5 +235,6 @@ func NewAgentThreeAggressive() agent.Strategy {
 		sanctionHistory:   make(map[commons.ID]([]int)),
 		activeSanctionMap: make(map[commons.ID]sanctions.SanctionActivity),
 		sanctionLength:    0,
+		rng:               rand.New(rand.NewSource(rand.Int63())),
 	}
 }

--- a/pkg/infra/teams/team3/agent3.go
+++ b/pkg/infra/teams/team3/agent3.go
@@ -84,7 +84,6 @@ func (a *AgentThree) UpdateInternalState(baseAgent agent.BaseAgent, history *com
 			a.activeSanctionMap = sanctions.GlobalSanctionMap
 			a.sanctionHistory = sanctions.GlobalSanctionHistory
 		}
-
 	}
 	// fetch total attack and defence
 	a.AT = int(AS.Attack + AS.BonusAttack())
@@ -140,7 +139,7 @@ func (a *AgentThree) UpdatePersonality(baseAgent agent.BaseAgent) {
 	// scale
 	increment := (pc * a.alpha)
 
-	// keep with max perosnality swing
+	// keep with max personality swing
 	if math.IsNaN(increment) {
 		increment = 0.0
 	}

--- a/pkg/infra/teams/team3/election_strat.go
+++ b/pkg/infra/teams/team3/election_strat.go
@@ -3,15 +3,10 @@ package team3
 import (
 	"infra/game/agent"
 	"infra/game/commons"
-	"math"
-	"sort"
-	"time"
-
 	"infra/game/decision"
 	"infra/game/state"
-
-	// "infra/logging"
-	"math/rand"
+	"math"
+	"sort"
 
 	"github.com/benbjohnson/immutable"
 )
@@ -24,7 +19,7 @@ type pair struct {
 // Handle No Confidence vote
 func (a *AgentThree) HandleConfidencePoll(baseAgent agent.BaseAgent) decision.Intent {
 	// decide whether to vote in the no-confidence vote based on personality
-	toVote := rand.Intn(100)
+	toVote := a.rng.Intn(100)
 
 	if toVote < a.personality {
 		view := baseAgent.View()
@@ -85,7 +80,7 @@ func (a *AgentThree) HandleElectionBallot(baseAgent agent.BaseAgent, param *deci
 		return candidateArray[i].val > candidateArray[j].val
 	})
 	// should we vote?
-	makeVote := rand.Intn(100)
+	makeVote := a.rng.Intn(100)
 	// if makeVote is lower than personality, then vote.
 	if makeVote < a.personality {
 		// Create Ballot
@@ -174,8 +169,7 @@ func (a *AgentThree) Reputation(baseAgent agent.BaseAgent) {
 
 	ids := commons.ImmutableMapKeys(vAS)
 	// get random shuffle of agent ids
-	rand.Seed(time.Now().UnixNano())
-	rand.Shuffle(len(ids), func(i, j int) { ids[i], ids[j] = ids[j], ids[i] })
+	a.rng.Shuffle(len(ids), func(i, j int) { ids[i], ids[j] = ids[j], ids[i] })
 
 	productivity := 5.0
 	needs := 5.0

--- a/pkg/infra/teams/team3/election_strat.go
+++ b/pkg/infra/teams/team3/election_strat.go
@@ -2,11 +2,10 @@ package team3
 
 import (
 	"infra/game/agent"
-	"time"
-
 	"infra/game/commons"
 	"math"
 	"sort"
+	"time"
 
 	"infra/game/decision"
 	"infra/game/state"

--- a/pkg/infra/teams/team3/election_strat.go
+++ b/pkg/infra/teams/team3/election_strat.go
@@ -66,7 +66,6 @@ func (a *AgentThree) HandleConfidencePoll(baseAgent agent.BaseAgent) decision.In
 }
 
 func (a *AgentThree) HandleElectionBallot(baseAgent agent.BaseAgent, param *decision.ElectionParams) decision.Ballot {
-
 	// extract the name of the agents who have submitted manifestos
 	candidateArray := make([]pair, 0, param.CandidateList().Len())
 	iterator := param.CandidateList().Iterator()

--- a/pkg/infra/teams/team3/fight_strat.go
+++ b/pkg/infra/teams/team3/fight_strat.go
@@ -71,7 +71,7 @@ func (a *AgentThree) HandleFightInformation(m message.TaggedInformMessage[messag
 	// fmt.Println(m)
 
 	// should i make a proposal (based on personality)
-	makesProposal := rand.Intn(100)
+	makesProposal := a.rng.Intn(100)
 	// if makesProposal is lower than personality, then make proposal
 	// low personality scores mean more selfish,
 	if makesProposal < a.personality {
@@ -150,7 +150,7 @@ func (a *AgentThree) CurrentAction(baseAgent agent.BaseAgent) decision.FightActi
 // HandleFightProposal Vote on proposal
 func (a *AgentThree) HandleFightProposal(m message.Proposal[decision.FightAction], baseAgent agent.BaseAgent) decision.Intent {
 	// determine whether to vote based on personality.
-	intent := rand.Intn(100)
+	intent := a.rng.Intn(100)
 
 	// rules := m.Rules()
 	// itr := rules.Iterator()

--- a/pkg/infra/teams/team3/fight_strat.go
+++ b/pkg/infra/teams/team3/fight_strat.go
@@ -201,7 +201,7 @@ func (a *AgentThree) thresholdDecision(baseAgent agent.BaseAgent, choice decisio
 
 		return thresholds
 	}
-	// caluclate the thresholds (for all the decisions)
+	// calculate the thresholds (for all the decisions)
 	thresholds.Health = (myStats.Health + alpha*Delta1HP) * float64(0.98)
 	thresholds.Stamina = (myStats.Stamina + alpha*Delta1ST) * float64(0.98)
 	thresholds.Attack = (myStats.Attack + alpha*Delta1ATT) * float64(0.98)

--- a/pkg/infra/teams/team3/fight_strat.go
+++ b/pkg/infra/teams/team3/fight_strat.go
@@ -147,7 +147,7 @@ func (a *AgentThree) CurrentAction(baseAgent agent.BaseAgent) decision.FightActi
 	return decision.Attack
 }
 
-// Vote on proposal
+// HandleFightProposal Vote on proposal
 func (a *AgentThree) HandleFightProposal(m message.Proposal[decision.FightAction], baseAgent agent.BaseAgent) decision.Intent {
 	// determine whether to vote based on personality.
 	intent := rand.Intn(100)

--- a/pkg/infra/teams/team3/helpers.go
+++ b/pkg/infra/teams/team3/helpers.go
@@ -5,8 +5,6 @@ import (
 	"infra/game/agent"
 	"infra/game/commons"
 	"math"
-	"math/rand"
-
 	// "os"
 	"strconv"
 )
@@ -188,7 +186,7 @@ func (a *AgentThree) InitUtility(baseAgent agent.BaseAgent) map[commons.ID]int {
 	for !itr.Done() {
 		id, _, _ := itr.Next()
 
-		u[id] = rand.Intn(10)
+		u[id] = a.rng.Intn(10)
 	}
 	return u
 }

--- a/pkg/infra/teams/team3/leader_strat.go
+++ b/pkg/infra/teams/team3/leader_strat.go
@@ -34,7 +34,7 @@ func (a *AgentThree) CreateManifesto(_ agent.BaseAgent) *decision.Manifesto {
 
 // Leader function to grant the floor?
 func (a *AgentThree) HandleFightProposalRequest(_ message.Proposal[decision.FightAction], _ agent.BaseAgent, _ *immutable.Map[commons.ID, decision.FightAction]) bool {
-	switch rand.Intn(2) {
+	switch a.rng.Intn(2) {
 	case 0:
 		return true
 	default:

--- a/pkg/infra/teams/team3/leader_strat.go
+++ b/pkg/infra/teams/team3/leader_strat.go
@@ -200,7 +200,6 @@ func (a *AgentThree) sanctioningDynamic(agent agent.Agent) int {
 	}
 
 	return currSanctionDur
-
 }
 
 func (a *AgentThree) updateSanctionHistory(agent agent.Agent, sanctionDuration int) {
@@ -251,12 +250,10 @@ func (a *AgentThree) SortAgentsArray(agentMap map[commons.ID]agent.Agent) []agen
 }
 
 func (a *AgentThree) PruneAgentList(agentMap map[commons.ID]agent.Agent) map[commons.ID]agent.Agent {
-
 	cmdParams := cmdline.CmdLineInits
 
 	pruned := make(map[commons.ID]agent.Agent)
 	for id, agent := range agentMap {
-
 		currentSanction, sanctionExists := a.activeSanctionMap[id]
 		if sanctionExists {
 			a.updateSanctionMap(id, currentSanction)
@@ -286,7 +283,6 @@ func (a *AgentThree) PruneAgentList(agentMap map[commons.ID]agent.Agent) map[com
 			if sanctionDuration == 0 {
 				pruned[id] = agent
 			}
-
 		}
 	}
 	return pruned

--- a/pkg/infra/teams/team3/loot_strat.go
+++ b/pkg/infra/teams/team3/loot_strat.go
@@ -92,13 +92,10 @@ func (a *AgentThree) HandleLootInformation(m message.TaggedInformMessage[message
 
 // forcibly call at start of loot phase to begin proceedings
 func (a *AgentThree) RequestLootProposal(baseAgent agent.BaseAgent) { // put your logic here now, instead
-	a.mutex.Lock()
 	sendProposal := rand.Intn(100)
 	if sendProposal > a.personality {
-		a.mutex.Unlock()
 		return
 	}
-	a.mutex.Unlock()
 	// general and send a loot proposal at the start of every turn
 	baseAgent.SendLootProposalToLeader(a.generateLootProposal(baseAgent))
 }

--- a/pkg/infra/teams/team3/loot_strat.go
+++ b/pkg/infra/teams/team3/loot_strat.go
@@ -175,7 +175,7 @@ func (a *AgentThree) LootThresholdDecision(baseAgent agent.BaseAgent) thresholdV
 
 	// 	return thresholds
 	// }
-	// caluclate the thresholds (for all the decisions)
+	// calculate the thresholds (for all the decisions)
 	thresholds.Health = (myStats.Health + alpha*Delta1HP) * float64(1.02)
 	thresholds.Stamina = (myStats.Stamina + alpha*Delta1ST) * float64(1.02)
 	thresholds.Attack = (myStats.Attack + alpha*Delta1ATT) * float64(1.05)

--- a/pkg/infra/teams/team3/messaging.go
+++ b/pkg/infra/teams/team3/messaging.go
@@ -1,6 +1,7 @@
 package team3
 
 import (
+	"github.com/benbjohnson/immutable"
 	"infra/game/agent"
 	"infra/game/commons"
 	"infra/game/message"
@@ -16,11 +17,10 @@ func agentInList(agentID commons.ID, messageList []commons.ID) bool {
 }
 
 // This is where you must compile your trust message. My example implementation takes ALL agents from the agent map **
-func (a *AgentThree) CompileTrustMessage(agentMap map[commons.ID]agent.Agent) message.Trust {
+func (a *AgentThree) CompileTrustMessage(agentMap *immutable.Map[commons.ID, agent.Agent]) message.Trust {
 	// fmt.Println("AGENT 3 COMPOSED: message.Trust")
-
 	// faireness = the function ids --> reputation number: which is the gossip
-	num := int(a.samplePercent * float64(len(agentMap)))
+	num := int(a.samplePercent * float64(agentMap.Len()))
 	agentsToMessage := make([]commons.ID, num)
 
 	// Check TSN first
@@ -33,8 +33,10 @@ func (a *AgentThree) CompileTrustMessage(agentMap map[commons.ID]agent.Agent) me
 		i++
 	}
 
-	// Then fill remaining spots from the rest
-	for k := range agentMap {
+	iterator := agentMap.Iterator()
+
+	for !iterator.Done() {
+		k, _, _ := iterator.Next()
 		if i == num {
 			break
 		}

--- a/pkg/infra/teams/team3/messaging.go
+++ b/pkg/infra/teams/team3/messaging.go
@@ -19,7 +19,7 @@ func agentInList(agentID commons.ID, messageList []commons.ID) bool {
 // This is where you must compile your trust message. My example implementation takes ALL agents from the agent map **
 func (a *AgentThree) CompileTrustMessage(agentMap *immutable.Map[commons.ID, agent.Agent]) (*message.Trust, []commons.ID) {
 	// fmt.Println("AGENT 3 COMPOSED: message.Trust")
-	// faireness = the function ids --> reputation number: which is the gossip
+	// fairness = the function ids --> reputation number: which is the gossip
 	num := int(a.samplePercent * float64(agentMap.Len()))
 	agentsToMessage := make([]commons.ID, num)
 
@@ -52,15 +52,8 @@ func (a *AgentThree) CompileTrustMessage(agentMap *immutable.Map[commons.ID, age
 
 	// declare new trust message
 
-	// avoid concurrent write to/read from trust.Gossip
-	repMapDeepCopy := make(map[commons.ID]float64)
-
-	for k, v := range a.reputationMap {
-		repMapDeepCopy[k] = v
-	}
-
 	// send off
-	return message.NewTrust(repMapDeepCopy), agentsToMessage
+	return message.NewTrust(a.reputationMap), agentsToMessage
 }
 
 // You will receive a message of type "TaggedMessage"
@@ -70,8 +63,7 @@ func (a *AgentThree) HandleTrustMessage(m message.TaggedMessage) {
 	mes := m.Message()
 	t := mes.(*message.Trust)
 
-	// Gossip IS reputation map ---> one thread will read it, one thread will write it.
-	// Shallow copy introduced in Compile
+	// Gossip IS reputation map.
 	iterator := t.Gossip().Iterator()
 	for !iterator.Done() {
 		id, sentRep, _ := iterator.Next()

--- a/pkg/infra/teams/team3/messaging.go
+++ b/pkg/infra/teams/team3/messaging.go
@@ -4,7 +4,6 @@ import (
 	"infra/game/agent"
 	"infra/game/commons"
 	"infra/game/message"
-	"sync"
 )
 
 func agentInList(agentID commons.ID, messageList []commons.ID) bool {
@@ -72,9 +71,6 @@ func (a *AgentThree) HandleTrustMessage(m message.TaggedMessage) {
 	mes := m.Message()
 	t := mes.(message.Trust)
 
-	mutex := sync.Mutex{}
-	mutex.Lock()
-
 	// Gossip IS reputation map ---> one thread will read it, one thread will write it.
 	// Shallow copy introduced in Compile
 
@@ -91,7 +87,6 @@ func (a *AgentThree) HandleTrustMessage(m message.TaggedMessage) {
 
 	}
 	a.socialCap[m.Sender()] += 1
-	mutex.Unlock()
 	//fmt.Println("sender is", t.Recipients, m.Sender(), a.socialCap[m.Sender()])
 	// This function is type void - you can do whatever you want with it. I would suggest keeping a local dictionary
 

--- a/pkg/infra/teams/team3/messaging.go
+++ b/pkg/infra/teams/team3/messaging.go
@@ -84,10 +84,8 @@ func (a *AgentThree) HandleTrustMessage(m message.TaggedMessage) {
 		} else {
 			a.reputationMap[id] = sentRep
 		}
-
 	}
 	a.socialCap[m.Sender()] += 1
 	//fmt.Println("sender is", t.recipients, m.Sender(), a.socialCap[m.Sender()])
 	// This function is type void - you can do whatever you want with it. I would suggest keeping a local dictionary
-
 }


### PR DESCRIPTION
- Remove all ineffectual (& implicit) mutexes
- Eliminating all synchronized random
- Run over 20 iterations with scaling timeouts set with race detector
- Avoids rng synchronisation using `AgentThree`
